### PR TITLE
#S3-2.2.1.3  Forgot password endpoint

### DIFF
--- a/backend/src/main/java/com/tricolori/backend/infrastructure/presentation/controllers/AuthController.java
+++ b/backend/src/main/java/com/tricolori/backend/infrastructure/presentation/controllers/AuthController.java
@@ -1,5 +1,6 @@
 package com.tricolori.backend.infrastructure.presentation.controllers;
 
+import com.tricolori.backend.infrastructure.presentation.dtos.ForgotPasswordRequest;
 import com.tricolori.backend.infrastructure.presentation.dtos.LoginRequest;
 import com.tricolori.backend.infrastructure.presentation.dtos.LoginResponse;
 import jakarta.validation.Valid;
@@ -22,5 +23,11 @@ public class AuthController {
         LoginResponse response = new LoginResponse(token);
 
         return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/forgot-password")
+    public ResponseEntity<Void> forgotPassword(@Valid @RequestBody ForgotPasswordRequest request) {
+
+        return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/main/java/com/tricolori/backend/infrastructure/presentation/dtos/ForgotPasswordRequest.java
+++ b/backend/src/main/java/com/tricolori/backend/infrastructure/presentation/dtos/ForgotPasswordRequest.java
@@ -1,0 +1,8 @@
+package com.tricolori.backend.infrastructure.presentation.dtos;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record ForgotPasswordRequest(
+        @NotBlank @Email String email
+) {}


### PR DESCRIPTION
This pull request introduces a new endpoint for handling password reset requests in the authentication controller. The main changes add support for the "forgot password" feature, including a new DTO for request validation.

**New forgot password feature:**

* Added a `forgot-password` POST endpoint to the `AuthController` that accepts a validated `ForgotPasswordRequest` and returns an empty 200 OK response.
* Introduced the `ForgotPasswordRequest` DTO, which enforces that the `email` field is both non-blank and a valid email address.
* Imported the new `ForgotPasswordRequest` DTO into the `AuthController`.