### PR TITLE
#S3-2.2.1.3 Change driver activity status endpoint

### DIFF
--- a/backend/src/main/java/com/tricolori/backend/infrastructure/presentation/controllers/DriverController.java
+++ b/backend/src/main/java/com/tricolori/backend/infrastructure/presentation/controllers/DriverController.java
@@ -1,0 +1,18 @@
+package com.tricolori.backend.infrastructure.presentation.controllers;
+
+import com.tricolori.backend.infrastructure.presentation.dtos.ChangeDriverStatusRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/drivers")
+@RequiredArgsConstructor
+public class DriverController {
+
+    @PatchMapping("/{id}/status")
+    public ResponseEntity<Void> changeStatus(@RequestBody ChangeDriverStatusRequest request, @PathVariable Long id) {
+
+        return ResponseEntity.ok().build();
+    }
+}

--- a/backend/src/main/java/com/tricolori/backend/infrastructure/presentation/dtos/ChangeDriverStatusRequest.java
+++ b/backend/src/main/java/com/tricolori/backend/infrastructure/presentation/dtos/ChangeDriverStatusRequest.java
@@ -1,0 +1,5 @@
+package com.tricolori.backend.infrastructure.presentation.dtos;
+
+public record ChangeDriverStatusRequest(
+   boolean isActive
+) {}


### PR DESCRIPTION
This pull request introduces a new API endpoint for updating a driver's status in the backend. It adds a controller to handle the status change request and defines a corresponding DTO for the request body.

**API endpoint addition:**

* Added `DriverController` with a `PATCH /api/v1/drivers/{id}/status` endpoint to handle driver status updates. The endpoint currently accepts a `ChangeDriverStatusRequest` and returns an empty response.

**DTO definition:**

* Introduced the `ChangeDriverStatusRequest` record to encapsulate the `isActive` property in the request body for changing a driver's status.