### PR TITLE
#S3-2.1.2.1 Ride estimation endpoint

### DIFF
--- a/backend/src/main/java/com/tricolori/backend/infrastructure/presentation/controllers/RideController.java
+++ b/backend/src/main/java/com/tricolori/backend/infrastructure/presentation/controllers/RideController.java
@@ -1,0 +1,23 @@
+package com.tricolori.backend.infrastructure.presentation.controllers;
+
+import com.tricolori.backend.infrastructure.presentation.dtos.RideEstimationRequest;
+import com.tricolori.backend.infrastructure.presentation.dtos.RideEstimationResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/rides")
+@RequiredArgsConstructor
+public class RideController {
+
+    @PostMapping("/estimate")
+    public ResponseEntity<RideEstimationResponse> estimateRide(@Valid @RequestBody RideEstimationRequest request) {
+
+        return ResponseEntity.ok().build();
+    }
+}

--- a/backend/src/main/java/com/tricolori/backend/infrastructure/presentation/dtos/LocationDto.java
+++ b/backend/src/main/java/com/tricolori/backend/infrastructure/presentation/dtos/LocationDto.java
@@ -1,0 +1,7 @@
+package com.tricolori.backend.infrastructure.presentation.dtos;
+
+public record LocationDto(
+   String address,
+   Double latitude,
+   Double longitude
+) {}

--- a/backend/src/main/java/com/tricolori/backend/infrastructure/presentation/dtos/RideEstimationRequest.java
+++ b/backend/src/main/java/com/tricolori/backend/infrastructure/presentation/dtos/RideEstimationRequest.java
@@ -1,0 +1,8 @@
+package com.tricolori.backend.infrastructure.presentation.dtos;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record RideEstimationRequest(
+    @NotBlank String pickupAddress,
+    @NotBlank String destinationAddress
+) {}

--- a/backend/src/main/java/com/tricolori/backend/infrastructure/presentation/dtos/RideEstimationResponse.java
+++ b/backend/src/main/java/com/tricolori/backend/infrastructure/presentation/dtos/RideEstimationResponse.java
@@ -1,0 +1,13 @@
+package com.tricolori.backend.infrastructure.presentation.dtos;
+
+public record RideEstimationResponse(
+
+        LocationDto pickupLocation,
+        LocationDto destinationLocation,
+
+        Long estimatedTimeSeconds, // e.g. 900 (15 min)
+        Double estimatedDistanceKm, // e.g. 5.2
+        Double estimatedPrice,      // e.g. 650.00
+
+        String routeGeometry
+) {}


### PR DESCRIPTION
This pull request introduces the initial implementation for ride estimation API endpoints and related DTOs. It adds a new controller to handle ride estimation requests, along with request and response data transfer objects (DTOs) to structure the API payloads.

**API Endpoint Implementation:**

- Added a new `RideController` class with a `/api/v1/rides/estimate` POST endpoint to handle ride estimation requests. The endpoint currently returns an empty response body.

**Data Transfer Objects (DTOs):**

- Introduced `RideEstimationRequest` DTO to represent incoming ride estimation requests, including validation for required fields (`pickupAddress` and `destinationAddress`).
- Added `RideEstimationResponse` DTO to structure the API response, including pickup and destination locations, estimated time, distance, price, and route geometry.
- Created `LocationDto` record to encapsulate address and coordinates for use in ride estimation responses.