### PR TITLE
#S3-2.6.5.1 Stop ride endpoint

### DIFF
--- a/backend/src/main/java/com/tricolori/backend/infrastructure/presentation/controllers/RideController.java
+++ b/backend/src/main/java/com/tricolori/backend/infrastructure/presentation/controllers/RideController.java
@@ -1,8 +1,6 @@
 package com.tricolori.backend.infrastructure.presentation.controllers;
 
-import com.tricolori.backend.infrastructure.presentation.dtos.CancelRideRequest;
-import com.tricolori.backend.infrastructure.presentation.dtos.RideEstimationRequest;
-import com.tricolori.backend.infrastructure.presentation.dtos.RideEstimationResponse;
+import com.tricolori.backend.infrastructure.presentation.dtos.*;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -24,4 +22,11 @@ public class RideController {
 
         return ResponseEntity.ok().build();
     }
+
+    @PutMapping("/{id}/stop")
+    public ResponseEntity<StopRideResponse> stopRide(@Valid @RequestBody StopRideRequest request, @PathVariable Long id) {
+
+        return ResponseEntity.ok().build();
+    }
+
 }

--- a/backend/src/main/java/com/tricolori/backend/infrastructure/presentation/dtos/StopRideRequest.java
+++ b/backend/src/main/java/com/tricolori/backend/infrastructure/presentation/dtos/StopRideRequest.java
@@ -1,0 +1,8 @@
+package com.tricolori.backend.infrastructure.presentation.dtos;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+
+public record StopRideRequest(
+        @NotNull @Valid LocationDto location
+) {}

--- a/backend/src/main/java/com/tricolori/backend/infrastructure/presentation/dtos/StopRideResponse.java
+++ b/backend/src/main/java/com/tricolori/backend/infrastructure/presentation/dtos/StopRideResponse.java
@@ -1,0 +1,7 @@
+package com.tricolori.backend.infrastructure.presentation.dtos;
+
+import jakarta.validation.constraints.NotNull;
+
+public record StopRideResponse(
+   @NotNull Double updatedPrice
+) {}


### PR DESCRIPTION
This pull request introduces a new endpoint to allow stopping a ride and adds the necessary request and response DTOs for this functionality. The main changes are the addition of the `stopRide` API in the `RideController` and the creation of `StopRideRequest` and `StopRideResponse` classes.

**New Stop Ride Feature:**

* Added a new `@PutMapping("/{id}/stop")` endpoint in `RideController` to handle ride stop requests, accepting a `StopRideRequest` and returning a `StopRideResponse`.
* Created `StopRideRequest` DTO to capture the location where the ride is stopped, requiring a non-null `LocationDto`.
* Created `StopRideResponse` DTO to return the updated price when a ride is stopped, requiring a non-null `Double` value.