### PR TITLE
#S2-2.11.1 Backend: Live Support Chat and DTOs

### DIFF
--- a/backend/src/main/java/com/tricolori/backend/infrastructure/presentation/controllers/SupportController.java
+++ b/backend/src/main/java/com/tricolori/backend/infrastructure/presentation/controllers/SupportController.java
@@ -1,0 +1,76 @@
+package com.tricolori.backend.infrastructure.presentation.controllers;
+
+import com.tricolori.backend.infrastructure.presentation.dtos.ChatConversationResponse;
+import com.tricolori.backend.infrastructure.presentation.dtos.ChatMessageRequest;
+import com.tricolori.backend.infrastructure.presentation.dtos.ChatMessageResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/support")
+@RequiredArgsConstructor
+public class SupportController {
+
+    /**
+     * 2.11 - Get chat history between current user and admins
+     * Returns all messages sent/received by current user with any admin
+     */
+    @GetMapping("/messages")
+    @PreAuthorize("hasAnyRole('PASSENGER', 'DRIVER')")
+    public ResponseEntity<List<ChatMessageResponse>> getMyMessages() {
+
+        return ResponseEntity.ok(List.of());
+    }
+
+    /**
+     * 2.11 - Send message to admin support (from passenger/driver)
+     * Creates a message with sender = current user, recipient = any available admin
+     */
+    @PostMapping("/messages")
+    @PreAuthorize("hasAnyRole('PASSENGER', 'DRIVER')")
+    public ResponseEntity<ChatMessageResponse> sendMessageToSupport(@Valid @RequestBody ChatMessageRequest request) {
+
+        return ResponseEntity.ok().build();
+    }
+
+    /**
+     * 2.11 - Get all users who have messaged support (for admin)
+     * Groups messages by user and shows last message info
+     */
+    @GetMapping("/conversations")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<List<ChatConversationResponse>> getAllConversations() {
+
+        return ResponseEntity.ok(List.of());
+    }
+
+    /**
+     * 2.11 - Get all messages with specific user (for admin)
+     * Shows full conversation history between any admin and the specified user
+     */
+    @GetMapping("/messages/{userId}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<List<ChatMessageResponse>> getMessagesWithUser(@PathVariable Long userId) {
+
+        return ResponseEntity.ok(List.of());
+    }
+
+    /**
+     * 2.11 - Send message to user as admin
+     * Creates a message with sender = current admin, recipient = specified user
+     */
+    @PostMapping("/messages/{userId}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<ChatMessageResponse> sendMessageToUser(
+            @PathVariable Long userId,
+            @Valid @RequestBody ChatMessageRequest request
+    ) {
+
+        return ResponseEntity.ok().build();
+    }
+}

--- a/backend/src/main/java/com/tricolori/backend/infrastructure/presentation/dtos/ChatConversationResponse.java
+++ b/backend/src/main/java/com/tricolori/backend/infrastructure/presentation/dtos/ChatConversationResponse.java
@@ -1,0 +1,11 @@
+package com.tricolori.backend.infrastructure.presentation.dtos;
+
+import java.time.LocalDateTime;
+
+public record ChatConversationResponse(
+        Long userId,
+        String userName,
+        String userRole,
+        String lastMessage,
+        LocalDateTime lastMessageTime
+) {}

--- a/backend/src/main/java/com/tricolori/backend/infrastructure/presentation/dtos/ChatMessageRequest.java
+++ b/backend/src/main/java/com/tricolori/backend/infrastructure/presentation/dtos/ChatMessageRequest.java
@@ -1,0 +1,11 @@
+// ChatMessageRequest.java
+package com.tricolori.backend.infrastructure.presentation.dtos;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record ChatMessageRequest(
+        @NotBlank
+        @Size(max = 1000)
+        String content
+) {}

--- a/backend/src/main/java/com/tricolori/backend/infrastructure/presentation/dtos/ChatMessageResponse.java
+++ b/backend/src/main/java/com/tricolori/backend/infrastructure/presentation/dtos/ChatMessageResponse.java
@@ -1,0 +1,13 @@
+package com.tricolori.backend.infrastructure.presentation.dtos;
+
+import java.time.LocalDateTime;
+
+public record ChatMessageResponse(
+        Long id,
+        String content,
+        LocalDateTime createdAt,
+        Long senderId,
+        String senderName,
+        Long recipientId,
+        String recipientName
+) {}


### PR DESCRIPTION
This pull request introduces the initial implementation of the support chat API endpoints and their related DTOs. It provides the controller structure and data transfer objects needed for chat functionality between users (passengers/drivers) and admins, including endpoints for sending and retrieving messages and conversations. The endpoints are stubbed out and ready for integration with business logic.

Support chat API endpoints:

* Added `SupportController` with endpoints for sending and retrieving support chat messages and conversations, with appropriate role-based access control. (`SupportController.java`)

Chat DTOs:

* Introduced `ChatMessageRequest` for validating incoming chat message content. (`ChatMessageRequest.java`)
* Added `ChatMessageResponse` to represent individual chat messages in API responses. (`ChatMessageResponse.java`)
* Created `ChatConversationResponse` for summarizing user-admin conversations, including last message details. (`ChatConversationResponse.java`)

Closes #43 