### PR TITLE
#S2-2.14.1 Backend: Pricelist Endpoint and DTOs

### DIFF
--- a/backend/src/main/java/com/tricolori/backend/infrastructure/presentation/controllers/PricelistController.java
+++ b/backend/src/main/java/com/tricolori/backend/infrastructure/presentation/controllers/PricelistController.java
@@ -1,0 +1,36 @@
+package com.tricolori.backend.infrastructure.presentation.controllers;
+
+import com.tricolori.backend.infrastructure.presentation.dtos.PriceConfigRequest;
+import com.tricolori.backend.infrastructure.presentation.dtos.PriceConfigResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/pricelist")
+@RequiredArgsConstructor
+public class PricelistController {
+
+    /**
+     * 2.14 - Get current pricing configuration
+     * Returns all base prices and the km price
+     */
+    @GetMapping
+    public ResponseEntity<PriceConfigResponse> getCurrentPricing() {
+
+        return ResponseEntity.ok().build();
+    }
+
+    /**
+     * 2.14 - Update pricing (admin only)
+     * Admin can define/change prices for all vehicle types and km price
+     */
+    @PutMapping
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<Void> updatePricing(@Valid @RequestBody PriceConfigRequest request) {
+
+        return ResponseEntity.ok().build();
+    }
+}

--- a/backend/src/main/java/com/tricolori/backend/infrastructure/presentation/dtos/PriceConfigRequest.java
+++ b/backend/src/main/java/com/tricolori/backend/infrastructure/presentation/dtos/PriceConfigRequest.java
@@ -1,0 +1,17 @@
+package com.tricolori.backend.infrastructure.presentation.dtos;
+
+import jakarta.validation.constraints.Min;
+
+public record PriceConfigRequest(
+        @Min(0)
+        Double standardPrice,
+
+        @Min(0)
+        Double luxuryPrice,
+
+        @Min(0)
+        Double vanPrice,
+
+        @Min(0)
+        Double kmPrice
+) {}

--- a/backend/src/main/java/com/tricolori/backend/infrastructure/presentation/dtos/PriceConfigResponse.java
+++ b/backend/src/main/java/com/tricolori/backend/infrastructure/presentation/dtos/PriceConfigResponse.java
@@ -1,0 +1,11 @@
+package com.tricolori.backend.infrastructure.presentation.dtos;
+
+import java.time.LocalDate;
+
+public record PriceConfigResponse(
+        Double standardPrice,
+        Double luxuryPrice,
+        Double vanPrice,
+        Double kmPrice,
+        LocalDate createdAt
+) {}


### PR DESCRIPTION
This pull request introduces a new pricing configuration API to the backend. It adds a controller for retrieving and updating pricing information, along with request and response DTOs to structure the data. The update endpoint is restricted to admin users and includes validation for input values.

**API Endpoints and Controller:**

* Added `PricelistController` with two endpoints:
  * `GET /api/v1/pricelist` to fetch the current pricing configuration (response structure defined by `PriceConfigResponse`)
  * `PUT /api/v1/pricelist` to update pricing (admin-only, input validated via `PriceConfigRequest`)

**DTOs for Pricing Configuration:**

* Introduced `PriceConfigRequest` record with minimum value validation for each price field to ensure non-negative pricing data
* Added `PriceConfigResponse` record to represent the pricing configuration, including a creation date field

Closes #46 