### PR TITLE
#S3-2.2.1.6 Reset password fragment

### DIFF
--- a/mobile/app/src/main/java/com/example/mobile/ui/fragments/ResetPasswordFragment.java
+++ b/mobile/app/src/main/java/com/example/mobile/ui/fragments/ResetPasswordFragment.java
@@ -1,0 +1,55 @@
+package com.example.mobile.ui.fragments;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+
+import com.example.mobile.R;
+import com.google.android.material.button.MaterialButton;
+import com.google.android.material.textfield.TextInputEditText;
+
+public class ResetPasswordFragment extends Fragment {
+
+    private TextInputEditText etNewPassword;
+    private TextInputEditText etConfirmPassword;
+    private MaterialButton btnSubmit;
+
+    public ResetPasswordFragment() {
+        // Required empty constructor
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        return inflater.inflate(R.layout.fragment_reset_password, container, false);
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+
+        etNewPassword = view.findViewById(R.id.etNewPassword);
+        etConfirmPassword = view.findViewById(R.id.etConfirmPassword);
+        btnSubmit = view.findViewById(R.id.btnSubmit);
+
+        btnSubmit.setOnClickListener(v -> {
+            String newPass = etNewPassword.getText().toString();
+            String confirmPass = etConfirmPassword.getText().toString();
+
+            if (newPass.isEmpty() || confirmPass.isEmpty()) {
+                Toast.makeText(getContext(), "Please fill in all fields", Toast.LENGTH_SHORT).show();
+            } else if (!newPass.equals(confirmPass)) {
+                Toast.makeText(getContext(), "Passwords do not match", Toast.LENGTH_SHORT).show();
+            } else {
+                Toast.makeText(getContext(), "Password changed successfully!", Toast.LENGTH_SHORT).show();
+                // TODO: Retrofit
+            }
+        });
+    }
+}

--- a/mobile/app/src/main/res/drawable/bg_requirements_card.xml
+++ b/mobile/app/src/main/res/drawable/bg_requirements_card.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/dark_100" /> <corners android:radius="@dimen/spacing_2" /> </shape>

--- a/mobile/app/src/main/res/layout/fragment_reset_password.xml
+++ b/mobile/app/src/main/res/layout/fragment_reset_password.xml
@@ -1,0 +1,180 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/white"
+    android:fillViewport="true"
+    tools:context=".ui.fragments.ResetPasswordFragment">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingStart="@dimen/spacing_4"
+        android:paddingTop="@dimen/spacing_16"
+        android:paddingEnd="@dimen/spacing_4"
+        android:paddingBottom="@dimen/spacing_4"
+        android:gravity="center_horizontal">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/spacing_2"
+            android:fontFamily="sans-serif"
+            android:text="@string/reset_pass_title"
+            android:textColor="@color/base_900"
+            android:textSize="@dimen/text_4xl"
+            android:textStyle="bold" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/spacing_8"
+            android:text="@string/reset_pass_subtitle"
+            android:textColor="@color/gray_600"
+            android:textSize="@dimen/text_base" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/spacing_2"
+                android:text="@string/label_new_pass"
+                android:textColor="@color/base_800"
+                android:textSize="@dimen/text_sm" />
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/spacing_4"
+                app:boxBackgroundColor="@color/white"
+                app:boxCornerRadiusBottomEnd="@dimen/spacing_2"
+                app:boxCornerRadiusBottomStart="@dimen/spacing_2"
+                app:boxCornerRadiusTopEnd="@dimen/spacing_2"
+                app:boxCornerRadiusTopStart="@dimen/spacing_2"
+                app:boxStrokeColor="@color/base_600"
+                app:boxStrokeWidth="1dp"
+                app:hintEnabled="false"
+                app:endIconMode="password_toggle"
+                app:endIconTint="@color/gray_400"
+                app:startIconDrawable="@drawable/ic_lock"
+                app:startIconTint="@color/gray_400"
+                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/etNewPassword"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/hint_new_pass"
+                    android:inputType="textPassword"
+                    android:paddingTop="@dimen/spacing_3"
+                    android:paddingBottom="@dimen/spacing_3"
+                    android:textColor="@color/gray_900"
+                    android:textSize="@dimen/text_base"/>
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/spacing_2"
+                android:text="@string/label_confirm_pass"
+                android:textColor="@color/base_800"
+                android:textSize="@dimen/text_sm" />
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/spacing_6"
+                app:boxBackgroundColor="@color/white"
+                app:boxCornerRadiusBottomEnd="@dimen/spacing_2"
+                app:boxCornerRadiusBottomStart="@dimen/spacing_2"
+                app:boxCornerRadiusTopEnd="@dimen/spacing_2"
+                app:boxCornerRadiusTopStart="@dimen/spacing_2"
+                app:boxStrokeColor="@color/base_600"
+                app:boxStrokeWidth="1dp"
+                app:hintEnabled="false"
+                app:endIconMode="password_toggle"
+                app:endIconTint="@color/gray_400"
+                app:startIconDrawable="@drawable/ic_lock"
+                app:startIconTint="@color/gray_400"
+                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/etConfirmPassword"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/hint_new_pass"
+                    android:inputType="textPassword"
+                    android:paddingTop="@dimen/spacing_3"
+                    android:paddingBottom="@dimen/spacing_3"
+                    android:textColor="@color/gray_900"
+                    android:textSize="@dimen/text_base"/>
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btnSubmit"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/spacing_12"
+                android:text="@string/btn_submit"
+                android:textAllCaps="false"
+                android:textSize="@dimen/text_lg"
+                android:textStyle="bold"
+                android:textColor="@color/white"
+                app:backgroundTint="@color/base_600"
+                app:cornerRadius="@dimen/spacing_2"
+                app:icon="@drawable/ic_arrow_right"
+                app:iconGravity="textEnd"
+                app:iconTint="@color/white" />
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/spacing_8"
+            android:background="@drawable/bg_requirements_card"
+            android:orientation="vertical"
+            android:padding="@dimen/spacing_5">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/spacing_3"
+                android:text="@string/req_title"
+                android:textColor="@color/base_700"
+                android:textSize="@dimen/text_base"
+                android:textStyle="bold" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/spacing_1"
+                android:text="@string/req_1"
+                android:textColor="@color/base_800"
+                android:textSize="@dimen/text_sm" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/spacing_1"
+                android:text="@string/req_2"
+                android:textColor="@color/base_800"
+                android:textSize="@dimen/text_sm" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/req_3"
+                android:textColor="@color/base_800"
+                android:textSize="@dimen/text_sm" />
+
+        </LinearLayout>
+
+    </LinearLayout>
+</ScrollView>

--- a/mobile/app/src/main/res/navigation/nav_graph.xml
+++ b/mobile/app/src/main/res/navigation/nav_graph.xml
@@ -33,4 +33,10 @@
         android:label="ForgotPasswordFragment"
         tools:layout="@layout/fragment_forgot_password" />
 
+    <fragment
+        android:id="@+id/resetPasswordFragment"
+        android:name="com.example.mobile.ui.fragments.ResetPasswordFragment"
+        android:label="ResetPasswordFragment"
+        tools:layout="@layout/fragment_reset_password" />
+
 </navigation>

--- a/mobile/app/src/main/res/values/strings.xml
+++ b/mobile/app/src/main/res/values/strings.xml
@@ -113,4 +113,15 @@
     <string name="step_2">• Click the link to reset your password</string>
     <string name="step_3">• Link expires in 24 hours</string>
     <string name="step_4">• Check your spam folder if not received</string>
+
+    <!-- Reset password -->
+    <string name="reset_pass_title">Reset your password</string>
+    <string name="reset_pass_subtitle">Choose a strong password to secure your account</string>
+    <string name="label_new_pass">Enter your new password:</string>
+    <string name="label_confirm_pass">Re-enter your new password:</string>
+    <string name="hint_new_pass">Your new password</string>
+    <string name="req_title">Password Requirements:</string>
+    <string name="req_1">• At least 8 characters</string>
+    <string name="req_2">• Upper and lowercase letters</string>
+    <string name="req_3">• At least one number</string>
 </resources>


### PR DESCRIPTION
This pull request adds a complete password reset feature to the mobile app, including a new fragment for resetting the password, its corresponding UI layout, navigation integration, supporting styles, and localized strings. The changes are grouped below by theme:

**Feature Implementation:**

* Added `ResetPasswordFragment` (`ResetPasswordFragment.java`) to handle password reset logic, including user input validation and feedback via Toast messages.

**UI and Layout:**

* Created the `fragment_reset_password.xml` layout, featuring fields for new and confirm password, a submit button, and a card displaying password requirements.
* Added a new background drawable for the requirements card (`bg_requirements_card.xml`) for visual consistency.

**Navigation:**

* Registered `ResetPasswordFragment` in the app's navigation graph (`nav_graph.xml`) to enable navigation to the new screen.

**Localization:**

* Added all necessary strings for the reset password feature to `strings.xml`, including titles, hints, labels, and requirements.