### PR TITLE
#S2-1.1.2 Frontend: Fix passenger home page route from login

### DIFF
--- a/web/src/app/features/auth/login/login.ts
+++ b/web/src/app/features/auth/login/login.ts
@@ -61,7 +61,7 @@ export class Login {
           break;
 
         case 'user': // passenger
-          this.router.navigate(['/home']);
+          this.router.navigate(['/passenger']);
           break;
 
         case 'admin':


### PR DESCRIPTION
This pull request makes a small update to the login flow. Now, when a user with the 'user' (passenger) role logs in, they are redirected to the `/passenger` route instead of `/home`.

Closes #98 