### PR TITLE
#S3-2.6.5.3 Stop ride backend

### DIFF
--- a/backend/src/main/java/com/tricolori/backend/core/domain/models/PriceList.java
+++ b/backend/src/main/java/com/tricolori/backend/core/domain/models/PriceList.java
@@ -1,5 +1,6 @@
 package com.tricolori.backend.core.domain.models;
 
+import com.tricolori.backend.shared.enums.VehicleType;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -36,5 +37,19 @@ public class PriceList {
 
     @Column(name = "km_price")
     private double kmPrice;
+
+    public Double getPriceForVehicleType(VehicleType type) {
+        switch (type) {
+            case LUXURY -> {
+                return luxuryPrice;
+            }
+            case VAN -> {
+                return vanPrice;
+            }
+            default -> {
+                return standardPrice;
+            }
+        }
+    }
 
 }

--- a/backend/src/main/java/com/tricolori/backend/core/domain/models/Ride.java
+++ b/backend/src/main/java/com/tricolori/backend/core/domain/models/Ride.java
@@ -121,4 +121,9 @@ public class Ride {
         return false;
     }
 
+    public void stop(Route updatedRoute) {
+        route = updatedRoute;
+        status = RideStatus.STOPPED;
+        endTime = LocalDateTime.now();
+    }
 }

--- a/backend/src/main/java/com/tricolori/backend/infrastructure/presentation/controllers/RideController.java
+++ b/backend/src/main/java/com/tricolori/backend/infrastructure/presentation/controllers/RideController.java
@@ -1,5 +1,6 @@
 package com.tricolori.backend.infrastructure.presentation.controllers;
 
+import com.tricolori.backend.core.domain.models.Person;
 import com.tricolori.backend.core.services.AuthService;
 import com.tricolori.backend.core.services.RideService;
 import com.tricolori.backend.infrastructure.presentation.dtos.*;
@@ -13,6 +14,7 @@ import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
@@ -72,8 +74,13 @@ public class RideController {
     }
 
     @PutMapping("/{id}/stop")
-    public ResponseEntity<StopRideResponse> stopRide(@Valid @RequestBody StopRideRequest request, @PathVariable Long id) {
-        return ResponseEntity.ok().build();
+    public ResponseEntity<StopRideResponse> stopRide(
+            @PathVariable Long id,
+            @Valid @RequestBody StopRideRequest request,
+            @AuthenticationPrincipal Person person
+    ) {
+
+        return ResponseEntity.ok(rideService.stopRide(id, person, request));
     }
 
     @GetMapping("/{id}/track")

--- a/backend/src/main/java/com/tricolori/backend/shared/enums/RideStatus.java
+++ b/backend/src/main/java/com/tricolori/backend/shared/enums/RideStatus.java
@@ -7,5 +7,6 @@ public enum RideStatus {
     PANIC,
     CANCELLED_BY_DRIVER,
     CANCELLED_BY_PASSENGER,
-    DECLINED
+    DECLINED,
+    STOPPED
 }


### PR DESCRIPTION
This pull request introduces a new "stop ride" feature, allowing drivers to stop an ongoing ride, update its status and route, and calculate the final price based on the vehicle type and distance. The main changes include updates to the domain model, service layer, controller, and supporting enums.

**Stop Ride Feature Implementation:**

* Added a `stop` method to the `Ride` entity that updates the ride's route, sets its status to `STOPPED`, and records the end time.
* Introduced a `stopRide` method in `RideService` to handle stopping a ride, including authorization checks, updating the ride, calculating the price, and returning a response DTO.
* Updated the `RideController` to expose a new `PUT /rides/{id}/stop` endpoint, which invokes the new service method and returns the stop ride response.

**Price Calculation Enhancements:**

* Added a `getPriceForVehicleType` method to the `PriceList` model to retrieve the base price depending on the vehicle type, supporting more flexible pricing logic.
* Updated the price calculation in `RideService` to use the new method, factoring in both vehicle type and distance.

**Supporting Changes:**

* Added the `STOPPED` status to the `RideStatus` enum to represent rides that have been stopped by the driver.
* Refactored imports and injected `PriceList` into `RideService` to support the new logic. 