### PR TITLE
#S3-2.6.5.2 Stop ride button for driver

### DIFF
--- a/web/src/app/core/services/ride.service.ts
+++ b/web/src/app/core/services/ride.service.ts
@@ -2,23 +2,23 @@ import { Injectable } from '@angular/core';
 import {HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
 
-import {PanicRequest} from '../../shared/model/ride';
+import {PanicRequest, StopRideRequest, StopRideResponse} from '../../shared/model/ride';
 import {environment} from '../../../environments/environment';
 
 // Interfaces matching your backend DTOs
 export interface RideHistoryResponse {
   id: number;
-  passengerName?: string;  
+  passengerName?: string;
   pickupAddress: string;
-  destinationAddress: string;  
+  destinationAddress: string;
   status: string;
-  price: number;  
-  distance?: number;  
-  duration?: number;  
-  startDate: string;  
-  endDate: string | null;  
-  driverRating?: number | null;  
-  vehicleRating?: number | null;  
+  price: number;
+  distance?: number;
+  duration?: number;
+  startDate: string;
+  endDate: string | null;
+  driverRating?: number | null;
+  vehicleRating?: number | null;
 }
 
 export interface RideDetailResponse {
@@ -88,8 +88,13 @@ export class RideService {
   ridePanic(rideId: number, panicRequest: PanicRequest): Observable<void> {
     return this.http.put<void>(`${this.API_URL}/${rideId}/panic`, panicRequest);
   }
-    
+
   cancelRide(rideId: number, reason: string) : Observable<void> {
     return this.http.put<void>(`${this.API_URL}/${rideId}/cancel`, { reason: reason });
   }
+
+  stopRide(rideId: number, stopRideRequest: StopRideRequest) : Observable<StopRideResponse> {
+    return this.http.put<StopRideResponse>(`${this.API_URL}/${rideId}/stop`, stopRideRequest);
+  }
+
 }

--- a/web/src/app/features/ride-tracking/driver/driver-ride-tracking.html
+++ b/web/src/app/features/ride-tracking/driver/driver-ride-tracking.html
@@ -67,6 +67,19 @@
     <!-- Spacer to push buttons to bottom -->
     <div class="flex-1"></div>
 
+    <!-- Stop Ride Button -->
+    <button
+      (click)="triggerStop()"
+      [disabled]="stopTriggered() || panicTriggered()"
+      class="w-full flex items-center justify-center gap-2 px-4 py-3 mb-3 bg-slate-800 hover:bg-slate-900 disabled:bg-slate-300 disabled:cursor-not-allowed text-white rounded-lg transition-all font-medium text-sm shadow-md active:scale-95">
+      <ng-icon name="heroStopCircle" class="w-5 h-5"></ng-icon>
+      @if (stopTriggered()) {
+        <span>Stopping Ride...</span>
+      } @else {
+        <span>STOP RIDE</span>
+      }
+    </button>
+
     <!-- Panic Button -->
     <button
       (click)="triggerPanic()"

--- a/web/src/app/features/ride-tracking/driver/driver-ride-tracking.ts
+++ b/web/src/app/features/ride-tracking/driver/driver-ride-tracking.ts
@@ -9,11 +9,12 @@ import {
   heroExclamationTriangle,
   heroCheckCircle,
   heroPhone,
-  heroExclamationCircle
+  heroExclamationCircle,
+  heroStopCircle
 } from '@ng-icons/heroicons/outline';
 import * as L from 'leaflet';
 import 'leaflet-routing-machine';
-import {PanicRequest, RideDetails} from '../../../shared/model/ride';
+import {PanicRequest, RideDetails, StopRideRequest, StopRideResponse} from '../../../shared/model/ride';
 import {Location} from '../../../shared/model/location';
 import {RideService} from '../../../core/services/ride.service';
 
@@ -30,7 +31,8 @@ import {RideService} from '../../../core/services/ride.service';
       heroExclamationTriangle,
       heroCheckCircle,
       heroPhone,
-      heroExclamationCircle
+      heroExclamationCircle,
+      heroStopCircle
     })
   ],
   templateUrl: './driver-ride-tracking.html'
@@ -303,6 +305,35 @@ export class DriverRideTrackingComponent implements OnInit, OnDestroy {
       this.vehicleMarker.openPopup();
     }
   }
+
+  stopTriggered = signal<boolean>(false);
+
+  triggerStop() : void {
+    if (this.stopTriggered()) {
+      return; // stop already triggered
+    }
+
+    const stopRideRequest : StopRideRequest = { location : this.vehicleLocation() }
+
+    this.rideService.stopRide(this.rideDetails().id, stopRideRequest).subscribe({
+      next: (response) => {
+        this.handleStop(response);
+        this.handleBack();
+      },
+      error: (err) => {
+        console.error("Failed stopping the ride: ", err);
+      }
+    })
+  }
+
+  private handleStop(response: StopRideResponse) : void {
+    this.stopTriggered.set(true);
+    this.stopTracking();
+    this.estimatedArrival.set(0);
+    this.remainingDistance.set(0);
+    console.log('Successfully stopped the ride. Updated price: ', response.updatedPrice);
+  }
+
 
   handleBack(): void {
     this.router.navigate(['/driver/home']);

--- a/web/src/app/shared/model/ride.ts
+++ b/web/src/app/shared/model/ride.ts
@@ -31,3 +31,11 @@ export interface RideDetails {
   totalDistance: number;
   estimatedDuration: number;
 }
+
+export interface StopRideRequest {
+  location: Location
+}
+
+export interface StopRideResponse {
+  updatedPrice: number
+}


### PR DESCRIPTION
This pull request introduces the "Stop Ride" feature for drivers, allowing them to stop an ongoing ride from the ride tracking interface. The implementation includes updates to the backend request/response models, service layer, component logic, and UI.

**Feature: Stop Ride Functionality**

*Model and Service Layer*
- Added new interfaces `StopRideRequest` and `StopRideResponse` to `ride.ts` to represent the stop ride request payload and response from the backend.
- Updated `RideService` to include a `stopRide` method that sends a stop ride request to the backend and returns the updated price.

*Component and UI Integration*
- Imported new models and the `heroStopCircle` icon into the driver ride tracking component. 
- Added a "Stop Ride" button to the driver ride tracking UI, which triggers the stop ride flow and displays a loading state while the request is in progress.
- Implemented `triggerStop` and `handleStop` methods in the driver ride tracking component to handle the stop ride action, update UI state, and process the backend response.