### PR TITLE
#S3-2.2.1.8 Refactor Password reset fragment

### DIFF
--- a/backend/src/main/java/com/tricolori/backend/entity/Ride.java
+++ b/backend/src/main/java/com/tricolori/backend/entity/Ride.java
@@ -133,8 +133,5 @@ public class Ride {
 
     public boolean isOngoing() {
         return this.status == RideStatus.ONGOING;
-    
-    public boolean containsPassengerWithEmail(String personEmail) {
-        return false;
     }
 }

--- a/mobile/app/src/main/java/com/example/mobile/ui/fragments/ResetPasswordFragment.java
+++ b/mobile/app/src/main/java/com/example/mobile/ui/fragments/ResetPasswordFragment.java
@@ -26,7 +26,7 @@ import retrofit2.Response;
 
 public class ResetPasswordFragment extends Fragment {
 
-    private TextInputEditText etToken;
+    private String mToken = null;
     private TextInputEditText etNewPassword;
     private TextInputEditText etConfirmPassword;
     private MaterialButton btnSubmit;
@@ -45,7 +45,6 @@ public class ResetPasswordFragment extends Fragment {
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
-        etToken = view.findViewById(R.id.etToken);
         etNewPassword = view.findViewById(R.id.etNewPassword);
         etConfirmPassword = view.findViewById(R.id.etConfirmPassword);
         btnSubmit = view.findViewById(R.id.btnSubmit);
@@ -53,40 +52,35 @@ public class ResetPasswordFragment extends Fragment {
         handleDeepLink();
 
         btnSubmit.setOnClickListener(v -> {
-            String token = etToken.getText().toString().trim();
             String newPass = etNewPassword.getText().toString().trim();
             String confirmPass = etConfirmPassword.getText().toString().trim();
 
-            if (token.isEmpty() || newPass.isEmpty() || confirmPass.isEmpty()) {
+            if (mToken == null || mToken.isEmpty()) {
+                Toast.makeText(getContext(), "Invalid reset session. Please use the link from your email.", Toast.LENGTH_LONG).show();
+            } else if (newPass.isEmpty() || confirmPass.isEmpty()) {
                 Toast.makeText(getContext(), "Please fill in all fields", Toast.LENGTH_SHORT).show();
             } else if (!newPass.equals(confirmPass)) {
                 Toast.makeText(getContext(), "Passwords do not match", Toast.LENGTH_SHORT).show();
             } else {
-                performResetPassword(token, newPass);
+                performResetPassword(mToken, newPass);
             }
         });
     }
 
     private void handleDeepLink() {
-        String tokenFromLink = null;
-
         if (getArguments() != null && getArguments().containsKey("token")) {
-            tokenFromLink = getArguments().getString("token");
+            mToken = getArguments().getString("token");
         }
 
-        if (tokenFromLink == null && requireActivity().getIntent() != null) {
-            Intent intent = requireActivity().getIntent();
-            Uri data = intent.getData();
+        if (mToken == null && requireActivity().getIntent() != null) {
+            Uri data = requireActivity().getIntent().getData();
             if (data != null) {
-                tokenFromLink = data.getQueryParameter("token");
+                mToken = data.getQueryParameter("token");
             }
         }
 
-        if (tokenFromLink != null && !tokenFromLink.isEmpty()) {
-            etToken.setText(tokenFromLink);
-            etToken.setEnabled(false);
-            Toast.makeText(getContext(), "Token applied successfully", Toast.LENGTH_SHORT).show();
-
+        if (mToken != null) {
+            Toast.makeText(getContext(), "Session verified", Toast.LENGTH_SHORT).show();
             requireActivity().getIntent().setData(null);
         }
     }
@@ -106,7 +100,6 @@ public class ResetPasswordFragment extends Fragment {
                     Navigation.findNavController(requireView()).navigate(R.id.action_resetPassword_to_login);
                 } else {
                     Toast.makeText(getContext(), "Error: Invalid or expired token", Toast.LENGTH_SHORT).show();
-                    etToken.setEnabled(true);
                 }
             }
 

--- a/mobile/app/src/main/res/layout/fragment_reset_password.xml
+++ b/mobile/app/src/main/res/layout/fragment_reset_password.xml
@@ -45,42 +45,6 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="@dimen/spacing_2"
-                android:text="@string/reset_token"
-                android:textColor="@color/base_800"
-                android:textSize="@dimen/text_sm" />
-
-            <com.google.android.material.textfield.TextInputLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="@dimen/spacing_4"
-                app:boxBackgroundColor="@color/white"
-                app:boxCornerRadiusBottomEnd="@dimen/spacing_2"
-                app:boxCornerRadiusBottomStart="@dimen/spacing_2"
-                app:boxCornerRadiusTopEnd="@dimen/spacing_2"
-                app:boxCornerRadiusTopStart="@dimen/spacing_2"
-                app:boxStrokeColor="@color/base_600"
-                app:boxStrokeWidth="1dp"
-                app:hintEnabled="false"
-                app:startIconDrawable="@drawable/ic_token"
-                app:startIconTint="@color/gray_400"
-                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox">
-
-                <com.google.android.material.textfield.TextInputEditText
-                    android:id="@+id/etToken"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:hint="@string/enter_token_from_email"
-                    android:inputType="text"
-                    android:paddingTop="@dimen/spacing_3"
-                    android:paddingBottom="@dimen/spacing_3"
-                    android:textColor="@color/gray_900"
-                    android:textSize="@dimen/text_base"/>
-            </com.google.android.material.textfield.TextInputLayout>
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="@dimen/spacing_2"
                 android:text="@string/label_new_pass"
                 android:textColor="@color/base_800"
                 android:textSize="@dimen/text_sm" />


### PR DESCRIPTION
This pull request simplifies and improves the password reset flow in the mobile app by removing the manual token entry field and ensuring the reset token is handled exclusively via deep links or navigation arguments. This reduces user error and streamlines the reset experience. Additionally, a minor cleanup was made in the backend code.

**Mobile app improvements:**

* Removed the token input field (`etToken`) from the UI and associated logic in `ResetPasswordFragment`, so users no longer need to manually enter the reset token. The token is now managed internally via navigation arguments or deep link, improving security and user experience.
* Updated validation and error handling in `ResetPasswordFragment` to ensure the reset token is always present before allowing password reset, and improved user feedback messages.
* Cleaned up the response handling after a failed reset attempt by removing unnecessary UI updates related to the now-removed token field.

**Backend cleanup:**

* Removed the unused `containsPassengerWithEmail` method from the `Ride` entity, reducing dead code.