### PR TITLE
#S3 Fix panic and ride route update

### DIFF
--- a/backend/src/main/java/com/tricolori/backend/dto/osrm/OSRMRouteResponse.java
+++ b/backend/src/main/java/com/tricolori/backend/dto/osrm/OSRMRouteResponse.java
@@ -12,7 +12,7 @@ public class OSRMRouteResponse {
     @Data
     public static class OSRMRoute {
         private Double distance; // in meters
-        private Double duration; // in seconds
+        private Long duration; // in seconds
         private String geometry; // encoded polyline
     }
 }

--- a/backend/src/main/java/com/tricolori/backend/entity/Route.java
+++ b/backend/src/main/java/com/tricolori/backend/entity/Route.java
@@ -48,4 +48,12 @@ public class Route {
         return stops.getLast();
     }
 
+    public void setDestinationStop(Stop stop) {
+        if (stops.isEmpty()) return;
+        Stop pickup = stops.getFirst();
+        stops.clear();
+        stops.add(pickup);
+        stops.add(stop);
+    }
+
 }

--- a/backend/src/main/java/com/tricolori/backend/service/GeocodingService.java
+++ b/backend/src/main/java/com/tricolori/backend/service/GeocodingService.java
@@ -49,4 +49,28 @@ public class GeocodingService {
         }
         throw new BadAddressException("Couldn't find lat and lng for address: " + address);
     }
+
+    public String getAddressFromCoordinates(double lat, double lng) {
+        String url = String.format("https://nominatim.openstreetmap.org/reverse?format=json&lat=%f&lon=%f", lat, lng);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("User-Agent", "Cuber/1.0 (mdujanovic03@gmail.com)");
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        try {
+            ResponseEntity<com.fasterxml.jackson.databind.JsonNode> response = restTemplate.exchange(
+                    url,
+                    HttpMethod.GET,
+                    entity,
+                    com.fasterxml.jackson.databind.JsonNode.class
+            );
+
+            if (response.getBody() != null && response.getBody().has("display_name")) {
+                return response.getBody().get("display_name").asText();
+            }
+        } catch (Exception e) {
+            System.err.println("Error while reverse geocoding: " + e.getMessage());
+        }
+        return "Non-existent location (" + lat + ", " + lng + ")";
+    }
 }

--- a/backend/src/main/java/com/tricolori/backend/service/RouteService.java
+++ b/backend/src/main/java/com/tricolori/backend/service/RouteService.java
@@ -94,7 +94,7 @@ public class RouteService {
         route.setStops(stops);
         route.setRouteGeometry(osrmRoute.getGeometry()); // encoded polyline
         route.setDistanceKm(osrmRoute.getDistance() / 1000.0); // iz metara u kilometre
-        route.setEstimatedTimeSeconds(osrmRoute.getDuration().longValue());
+        route.setEstimatedTimeSeconds(osrmRoute.getDuration());
 
         return routeRepository.save(route);
     }


### PR DESCRIPTION
This pull request introduces several improvements and refactorings to ride termination and geocoding logic. The main changes include adding reverse geocoding functionality, refactoring ride termination (including panic and stop actions) to update route and pricing information using live data, and updating data types for route durations for consistency.

**Ride termination and route update refactoring:**
- Added a private `terminateRideAtLocation` method in `RideService` to centralize logic for ending a ride (either by stopping or panic), updating the route's destination, geometry, estimated time, distance, and price using live geocoding and routing data. Both `panicRide` and the new `stopRide` now use this method.
- Removed the old `stopRide` implementation and replaced it with a version that uses the new centralized termination logic.

**Reverse geocoding feature:**
- Added `getAddressFromCoordinates` to `GeocodingService`, allowing the service to fetch a human-readable address from latitude and longitude using the Nominatim API. This is used when updating the route's destination stop.
- Injected `GeocodingService` into `RideService` to support reverse geocoding. 

**Data model and consistency improvements:**
- Changed the type of `duration` in `OSRMRouteResponse.OSRMRoute` from `Double` to `Long` for consistency, and updated all usages accordingly.
- Added a `setDestinationStop` method to the `Route` entity to update the destination stop while preserving the pickup stop.

These changes improve the accuracy and maintainability of ride termination logic, ensure up-to-date route and pricing information, and add reverse geocoding support for better user experience.