### PR TITLE
#S3-2.9.1.1 Passenger history endpoint and service

### DIFF
--- a/backend/src/main/java/com/tricolori/backend/controller/RideController.java
+++ b/backend/src/main/java/com/tricolori/backend/controller/RideController.java
@@ -3,8 +3,6 @@ package com.tricolori.backend.controller;
 import com.tricolori.backend.dto.ride.*;
 import com.tricolori.backend.entity.Location;
 import com.tricolori.backend.entity.Person;
-import com.tricolori.backend.entity.Route;
-import com.tricolori.backend.entity.Stop;
 import com.tricolori.backend.service.AuthService;
 import com.tricolori.backend.service.InconsistencyReportService;
 import com.tricolori.backend.service.ReviewService;
@@ -13,16 +11,17 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/api/v1/rides")
@@ -153,22 +152,17 @@ public class RideController {
         return ResponseEntity.ok(detail);
     }
 
-    // Get passenger's ride history
-    @GetMapping("/history/passenger")
+    @GetMapping("/passenger")
     @PreAuthorize("hasRole('PASSENGER')")
-    public ResponseEntity<List<PassengerRideHistoryResponse>> getPassengerHistory(
+    public ResponseEntity<Page<PassengerRideHistoryResponse>> getPassengerHistory(
+            @AuthenticationPrincipal Person person,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
-            @RequestParam(defaultValue = "createdAt") String sortBy,
-            @RequestParam(defaultValue = "DESC") String sortDirection
+            @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
-        Long passengerId = authenticationService.getAuthenticatedUserId();
 
-        Pageable pageable = Pageable.unpaged();
-
-        List<PassengerRideHistoryResponse> history =
-                rideService.getPassengerHistory(passengerId, pageable)
-                        .getContent();
+        Page<PassengerRideHistoryResponse> history =
+                rideService.getPassengerHistory(person, startDate, endDate, pageable);
 
         return ResponseEntity.ok(history);
     }

--- a/backend/src/main/java/com/tricolori/backend/repository/RideRepository.java
+++ b/backend/src/main/java/com/tricolori/backend/repository/RideRepository.java
@@ -102,12 +102,17 @@ public interface RideRepository extends JpaRepository<Ride, Long> {
             Pageable pageable
     );
 
-    // all passenger rides
     @Query("SELECT r FROM Ride r " +
             "JOIN r.passengers p " +
             "WHERE p.id = :passengerId " +
-            "ORDER BY r.createdAt DESC")
-    Page<Ride> findAllPassengerRides(@Param("passengerId") Long passengerId, Pageable pageable);
+            "AND (CAST(:startDate AS timestamp) IS NULL OR r.createdAt >= :startDate) " +
+            "AND (CAST(:endDate AS timestamp) IS NULL OR r.createdAt <= :endDate)")
+    Page<Ride> findAllPassengerRides(
+            @Param("passengerId") Long passengerId,
+            @Param("startDate") LocalDateTime startDate,
+            @Param("endDate") LocalDateTime endDate,
+            Pageable pageable
+    );
 
     // passenger rides filtered by date
     @Query("""

--- a/backend/src/main/java/com/tricolori/backend/service/RideService.java
+++ b/backend/src/main/java/com/tricolori/backend/service/RideService.java
@@ -12,9 +12,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 
 import com.tricolori.backend.dto.ride.*;
@@ -120,11 +121,13 @@ public class RideService {
     // ================= passenger =================
 
     public Page<PassengerRideHistoryResponse> getPassengerHistory(
-            Long passengerId,
-            Pageable pageable
+            Person person, LocalDate startDate, LocalDate endDate, Pageable pageable
     ) {
+        LocalDateTime start = (startDate != null) ? startDate.atStartOfDay() : null;
+        LocalDateTime end = (endDate != null) ? endDate.atTime(LocalTime.MAX) : null;
+
         return rideRepository
-                .findAllPassengerRides(passengerId, pageable)
+                .findAllPassengerRides(person.getId(), start, end, pageable)
                 .map(rideMapper::toPassengerHistoryResponse);
     }
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -379,6 +379,24 @@
         }
       }
     },
+    "node_modules/@angular-devkit/schematics/node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@angular-devkit/schematics/node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -387,6 +405,22 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/@angular-devkit/schematics/node_modules/readdirp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@angular/build": {
@@ -586,6 +620,40 @@
         "chokidar": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@angular/cli/node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@angular/cli/node_modules/readdirp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@angular/common": {
@@ -4042,6 +4110,40 @@
         "chokidar": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@schematics/angular/node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@schematics/angular/node_modules/readdirp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@sigstore/bundle": {


### PR DESCRIPTION
This pull request refactors how passenger ride history is fetched and filtered in the backend, improving both the API and database query logic. It also updates the frontend dependencies by adding new package entries. The main changes include switching to pageable, filterable queries for passenger ride history, updating repository and service methods accordingly, and synchronizing dependency lock files.

### Backend API and Logic Improvements

**Passenger Ride History Endpoint:**
- The `/api/v1/rides/passenger` endpoint now returns a pageable response (`Page<PassengerRideHistoryResponse>`) instead of a list, and supports filtering by start and end dates using query parameters. Pagination and sorting are handled using Spring's `@PageableDefault`. This enables clients to efficiently fetch and filter large ride histories.
- The service method `getPassengerHistory` in `RideService` is updated to accept a `Person` object and optional date range, converting these to `LocalDateTime` for accurate filtering.
- The repository method `findAllPassengerRides` now supports filtering by date range at the database level, improving performance for filtered queries.

**Dependency and Import Cleanups:**
- Removed unused imports from `RideController.java` and added necessary ones for pagination and date handling.
- Minor import adjustments in `RideService.java` for consistency.

### Frontend Dependency Updates

**NPM Package Lock File:**
- Added new entries for `chokidar` and `readdirp` (version 5.0.0) under various Angular-related dependencies in `package-lock.json`, likely as part of a dependency update or Angular CLI upgrade. 