### PR TITLE
#S1-2.2.3.a.6 Test: Frontend Admin Driver Registration

### DIFF
--- a/web/src/app/pages/auth/driver-register/components/step-one-form/step-one-form.spec.ts
+++ b/web/src/app/pages/auth/driver-register/components/step-one-form/step-one-form.spec.ts
@@ -1,0 +1,228 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { provideIcons } from '@ng-icons/core';
+import { heroUser } from '@ng-icons/heroicons/outline';
+import { matAccountCircleOutline } from '@ng-icons/material-icons/outline';
+import { StepOneForm } from './step-one-form';
+import { Component, signal } from '@angular/core';
+import { PfpPicker } from '../../../../../components/pfp-picker/pfp-picker';
+import { StepOneDriverRegistrationData } from '../../../../../model/driver-registration';
+
+// Stub za PfpPicker da izbjegnemo kompleksnost child komponente
+@Component({ selector: 'app-pfp-picker', template: '', standalone: true })
+class PfpPickerStub {}
+
+describe('StepOneForm', () => {
+  let component: StepOneForm;
+  let fixture: ComponentFixture<StepOneForm>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+        imports: [StepOneForm, ReactiveFormsModule, PfpPicker],
+        providers: [
+        provideIcons({ 
+            heroUser, 
+            matAccountCircleOutline,
+        })
+        ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(StepOneForm);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+    });
+
+  // --- Kreiranje ---
+
+  it('should create the component', () => {
+    expect(component).toBeTruthy();
+  });
+
+  // --- Inicijalizacija forme ---
+
+  describe('Form Initialization', () => {
+    it('should initialize form with empty values', () => {
+      expect(component.firstName.value).toBe('');
+      expect(component.lastName.value).toBe('');
+      expect(component.phone.value).toBe('');
+      expect(component.address.value).toBe('');
+    });
+
+    it('should have invalid form when empty', () => {
+      expect(component.firstStepForm.valid).toBeFalsy();
+    });
+
+    it('should initialize selectedFile signal as null', () => {
+      expect(component.selectedFile()).toBeNull();
+    });
+  });
+
+  // --- Validacija ---
+
+  describe('Form Validation', () => {
+    it('should require firstName', () => {
+      expect(component.firstName.hasError('required')).toBeTruthy();
+
+      component.firstName.setValue('John');
+      expect(component.firstName.hasError('required')).toBeFalsy();
+    });
+
+    it('should require lastName', () => {
+      expect(component.lastName.hasError('required')).toBeTruthy();
+
+      component.lastName.setValue('Doe');
+      expect(component.lastName.hasError('required')).toBeFalsy();
+    });
+
+    it('should require phone', () => {
+      expect(component.phone.hasError('required')).toBeTruthy();
+
+      component.phone.setValue('+381641234567');
+      expect(component.phone.hasError('required')).toBeFalsy();
+    });
+
+    it('should require address', () => {
+      expect(component.address.hasError('required')).toBeTruthy();
+
+      component.address.setValue('Bulevar Oslobodjenja 1');
+      expect(component.address.hasError('required')).toBeFalsy();
+    });
+
+    it('should be valid when all fields are filled', () => {
+      component.firstStepForm.patchValue({
+        firstName: 'John',
+        lastName: 'Doe',
+        phone: '+381641234567',
+        address: 'Bulevar Oslobodjenja 1'
+      });
+
+      expect(component.firstStepForm.valid).toBeTruthy();
+    });
+  });
+
+  // --- completeStep ---
+
+  describe('completeStep()', () => {
+    it('should not emit when form is invalid', () => {
+      let emitted = false;
+      const outputRef = fixture.componentRef.instance.newStepData;
+      outputRef.subscribe(() => emitted = true);
+
+      component.completeStep();
+
+      expect(emitted).toBeFalse();
+    });
+
+    it('should mark all fields as touched when form is invalid', () => {
+      component.completeStep();
+
+      expect(component.firstName.touched).toBeTruthy();
+      expect(component.lastName.touched).toBeTruthy();
+      expect(component.phone.touched).toBeTruthy();
+      expect(component.address.touched).toBeTruthy();
+    });
+
+    it('should emit newStepData when form is valid', () => {
+      let emittedData: StepOneDriverRegistrationData | undefined;
+      fixture.componentRef.instance.newStepData.subscribe((data: StepOneDriverRegistrationData) => emittedData = data);
+
+      component.firstStepForm.patchValue({
+        firstName: 'John',
+        lastName: 'Doe',
+        phone: '+381641234567',
+        address: 'Bulevar Oslobodjenja 1'
+      });
+
+      component.completeStep();
+
+      expect(emittedData).toBeDefined();
+      expect(emittedData?.firstName).toBe('John');
+      expect(emittedData?.lastName).toBe('Doe');
+      expect(emittedData?.phone).toBe('+381641234567');
+      expect(emittedData?.address).toBe('Bulevar Oslobodjenja 1');
+    });
+
+    it('should include pfpFile in emitted data', () => {
+      let emittedData: StepOneDriverRegistrationData | undefined;
+      fixture.componentRef.instance.newStepData.subscribe((data: StepOneDriverRegistrationData) => emittedData = data);
+
+      const mockFile = new File(['img'], 'photo.jpg', { type: 'image/jpeg' });
+      component.selectedFile.set(mockFile);
+
+      component.firstStepForm.patchValue({
+        firstName: 'John',
+        lastName: 'Doe',
+        phone: '+381641234567',
+        address: 'Bulevar Oslobodjenja 1'
+      });
+
+      component.completeStep();
+
+      expect(emittedData?.pfpFile).toBe(mockFile);
+    });
+
+    it('should include null pfpFile when no file selected', () => {
+      let emittedData: StepOneDriverRegistrationData | undefined;
+      fixture.componentRef.instance.newStepData.subscribe((data: StepOneDriverRegistrationData) => emittedData = data);
+
+      component.firstStepForm.patchValue({
+        firstName: 'John',
+        lastName: 'Doe',
+        phone: '+381641234567',
+        address: 'Bulevar Oslobodjenja 1'
+      });
+
+      component.completeStep();
+
+      expect(emittedData?.pfpFile).toBeNull();
+    });
+  });
+
+  // --- handleNewFile ---
+
+  describe('handleNewFile()', () => {
+    it('should update selectedFile signal', () => {
+      const mockFile = new File(['img'], 'photo.jpg', { type: 'image/jpeg' });
+      component.handleNewFile(mockFile);
+      expect(component.selectedFile()).toBe(mockFile);
+    });
+  });
+
+  // --- oldStepData input (patch) ---
+
+  describe('oldStepData input', () => {
+    it('should patch form when oldStepData is provided', () => {
+      const oldData: StepOneDriverRegistrationData = {
+        firstName: 'Marko',
+        lastName: 'Markovic',
+        phone: '+381611111111',
+        address: 'Jovana Subotica 5',
+        pfpFile: null
+      };
+
+      fixture.componentRef.setInput('oldStepData', oldData);
+      fixture.detectChanges();
+
+      expect(component.firstName.value).toBe('Marko');
+      expect(component.lastName.value).toBe('Markovic');
+      expect(component.phone.value).toBe('+381611111111');
+      expect(component.address.value).toBe('Jovana Subotica 5');
+    });
+
+    it('should set selectedFile from oldStepData', () => {
+      const mockFile = new File(['img'], 'old.jpg', { type: 'image/jpeg' });
+      const oldData: StepOneDriverRegistrationData = {
+        firstName: 'Marko',
+        lastName: 'Markovic',
+        phone: '+381611111111',
+        address: 'Jovana Subotica 5',
+        pfpFile: mockFile
+      };
+
+      fixture.componentRef.setInput('oldStepData', oldData);
+      fixture.detectChanges();
+
+      expect(component.selectedFile()).toBe(mockFile);
+    });
+  });
+});

--- a/web/src/app/pages/auth/driver-register/components/step-two-form/step-two-form.spec.ts
+++ b/web/src/app/pages/auth/driver-register/components/step-two-form/step-two-form.spec.ts
@@ -1,0 +1,214 @@
+
+import { StepTwoForm } from './step-two-form';
+import { hugeCar03 } from '@ng-icons/huge-icons';
+import { mynaBaby } from '@ng-icons/mynaui/outline';
+import { phosphorDog } from '@ng-icons/phosphor-icons/regular';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { provideIcons } from '@ng-icons/core';
+import { StepTwoDriverRegistrationData } from '../../../../../model/driver-registration';
+
+describe('StepTwoForm', () => {
+  let component: StepTwoForm;
+  let fixture: ComponentFixture<StepTwoForm>;
+
+  const validFormData = {
+    email: 'driver@example.com',
+    vehicleModel: 'Toyota Corolla',
+    vehicleType: 'standard',
+    registrationPlate: 'NS-1234-AB',
+    seatNumber: 4,
+    petFriendly: false,
+    babyFriendly: false
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [StepTwoForm, ReactiveFormsModule],
+      providers: [
+        provideIcons({ hugeCar03, mynaBaby, phosphorDog })
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(StepTwoForm);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  // --- Kreiranje ---
+
+  it('should create the component', () => {
+    expect(component).toBeTruthy();
+  });
+
+  // --- Inicijalizacija ---
+
+  describe('Form Initialization', () => {
+    it('should initialize email as empty', () => {
+      expect(component.email.value).toBe('');
+    });
+
+    it('should initialize vehicleModel as empty', () => {
+      expect(component.vehicleModel.value).toBe('');
+    });
+
+    it('should initialize registrationPlate as empty', () => {
+      expect(component.registrationPlate.value).toBe('');
+    });
+
+    it('should initialize seatNumber as empty', () => {
+      expect(component.seatNumber.value).toBe('');
+    });
+
+    it('should initialize petFriendly as false', () => {
+      expect(component.petFriendly.value).toBeFalse();
+    });
+
+    it('should initialize babyFriendly as false', () => {
+      expect(component.babyFriendly.value).toBeFalse();
+    });
+
+    it('should have invalid form when empty', () => {
+      expect(component.secondStepForm.valid).toBeFalsy();
+    });
+  });
+
+  // --- Validacija ---
+
+  describe('Form Validation', () => {
+    it('should require email', () => {
+      expect(component.email.hasError('required')).toBeTruthy();
+    });
+
+    it('should validate email format', () => {
+      component.email.setValue('invalid-email');
+      expect(component.email.hasError('email')).toBeTruthy();
+
+      component.email.setValue('valid@email.com');
+      expect(component.email.valid).toBeTruthy();
+    });
+
+    it('should require vehicleModel', () => {
+      expect(component.vehicleModel.hasError('required')).toBeTruthy();
+
+      component.vehicleModel.setValue('Toyota Corolla');
+      expect(component.vehicleModel.hasError('required')).toBeFalsy();
+    });
+
+    it('should require registrationPlate', () => {
+      expect(component.registrationPlate.hasError('required')).toBeTruthy();
+
+      component.registrationPlate.setValue('NS-1234-AB');
+      expect(component.registrationPlate.hasError('required')).toBeFalsy();
+    });
+
+    it('should require seatNumber', () => {
+      expect(component.seatNumber.hasError('required')).toBeTruthy();
+    });
+
+    it('should require seatNumber to be at least 1', () => {
+      component.seatNumber.setValue(0);
+      expect(component.seatNumber.hasError('min')).toBeTruthy();
+
+      component.seatNumber.setValue(1);
+      expect(component.seatNumber.hasError('min')).toBeFalsy();
+    });
+
+    it('should be valid when all required fields are filled correctly', () => {
+      component.secondStepForm.patchValue(validFormData);
+      expect(component.secondStepForm.valid).toBeTruthy();
+    });
+  });
+
+  // --- handleSubmit ---
+
+  describe('handleSubmit()', () => {
+    it('should not emit when form is invalid', () => {
+      let emitted = false;
+      fixture.componentRef.instance.newStepData.subscribe(() => emitted = true);
+
+      component.handleSubmit();
+
+      expect(emitted).toBeFalse();
+    });
+
+    it('should mark all fields as touched when form is invalid', () => {
+      component.handleSubmit();
+
+      expect(component.email.touched).toBeTruthy();
+      expect(component.vehicleModel.touched).toBeTruthy();
+      expect(component.registrationPlate.touched).toBeTruthy();
+      expect(component.seatNumber.touched).toBeTruthy();
+    });
+
+    it('should emit newStepData when form is valid', () => {
+      let emittedData: StepTwoDriverRegistrationData | undefined;
+      fixture.componentRef.instance.newStepData.subscribe((data: StepTwoDriverRegistrationData) => emittedData = data);
+
+      component.secondStepForm.patchValue(validFormData);
+      component.handleSubmit();
+
+      expect(emittedData).toBeDefined();
+      expect(emittedData?.email).toBe('driver@example.com');
+      expect(emittedData?.vehicleModel).toBe('Toyota Corolla');
+      expect(emittedData?.registrationPlate).toBe('NS-1234-AB');
+      expect(emittedData?.seatNumber).toBe(4);
+    });
+
+    it('should emit petFriendly and babyFriendly values', () => {
+      let emittedData: StepTwoDriverRegistrationData | undefined;
+      fixture.componentRef.instance.newStepData.subscribe((data: StepTwoDriverRegistrationData) => emittedData = data);
+
+      component.secondStepForm.patchValue({ ...validFormData, petFriendly: true, babyFriendly: true });
+      component.handleSubmit();
+
+      expect(emittedData?.petFriendly).toBeTrue();
+      expect(emittedData?.babyFriendly).toBeTrue();
+    });
+  });
+
+  // --- goBack ---
+
+  describe('goBack()', () => {
+    it('should emit back output with current form values', () => {
+      let emittedData: StepTwoDriverRegistrationData | undefined;
+      fixture.componentRef.instance.back.subscribe((data: StepTwoDriverRegistrationData) => emittedData = data);
+
+      component.secondStepForm.patchValue(validFormData);
+      component.goBack();
+
+      expect(emittedData).toBeDefined();
+      expect(emittedData?.email).toBe('driver@example.com');
+    });
+
+    it('should emit back even when form is invalid', () => {
+      let emitted = false;
+      fixture.componentRef.instance.back.subscribe(() => emitted = true);
+
+      component.goBack();
+
+      expect(emitted).toBeTrue();
+    });
+  });
+
+  // --- oldStepData input ---
+
+  describe('oldStepData input', () => {
+    it('should patch form when oldStepData is provided', () => {
+      const oldData: StepTwoDriverRegistrationData = {
+        ...validFormData,
+        petFriendly: true,
+        babyFriendly: false
+      };
+
+      fixture.componentRef.setInput('oldStepData', oldData);
+      fixture.detectChanges();
+
+      expect(component.email.value).toBe('driver@example.com');
+      expect(component.vehicleModel.value).toBe('Toyota Corolla');
+      expect(component.registrationPlate.value).toBe('NS-1234-AB');
+      expect(component.seatNumber.value).toBe(4);
+      expect(component.petFriendly.value).toBeTrue();
+    });
+  });
+});

--- a/web/src/app/pages/auth/driver-register/driver-register.spec.ts
+++ b/web/src/app/pages/auth/driver-register/driver-register.spec.ts
@@ -1,0 +1,165 @@
+import { DriverRegister } from './driver-register';
+import { AuthService } from '../../../services/auth.service';
+import { of, throwError } from 'rxjs';
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { StepOneDriverRegistrationData, StepTwoDriverRegistrationData } from '../../../model/driver-registration';
+import { StepOneForm } from './components/step-one-form/step-one-form';
+import { StepTwoForm } from './components/step-two-form/step-two-form';
+
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+
+@Component({ selector: 'app-step-one-form', template: '', standalone: true })
+class StepOneFormStub {}
+
+@Component({ selector: 'app-step-two-form', template: '', standalone: true })
+class StepTwoFormStub {}
+
+describe('DriverRegister', () => {
+  let component: DriverRegister;
+  let fixture: ComponentFixture<DriverRegister>;
+  let authService: jasmine.SpyObj<AuthService>;
+
+  const mockStepOneData: StepOneDriverRegistrationData = {
+    firstName: 'John',
+    lastName: 'Doe',
+    phone: '+381641234567',
+    address: 'Bulevar Oslobodjenja 1',
+    pfpFile: null
+  };
+
+  const mockStepTwoData: StepTwoDriverRegistrationData = {
+    email: 'driver@example.com',
+    vehicleModel: 'Toyota Corolla',
+    vehicleType: 'standard',
+    registrationPlate: 'NS-1234-AB',
+    seatNumber: 4,
+    petFriendly: false,
+    babyFriendly: false
+  };
+
+  beforeEach(async () => {
+    const authServiceSpy = jasmine.createSpyObj('AuthService', ['registerDriver']);
+
+    await TestBed.configureTestingModule({
+      imports: [DriverRegister],
+      providers: [
+        { provide: AuthService, useValue: authServiceSpy }
+      ],
+      schemas: [NO_ERRORS_SCHEMA]  // ovo ignorise nepoznate property bindinge na child komponentama
+    }).compileComponents();
+
+    authService = TestBed.inject(AuthService) as jasmine.SpyObj<AuthService>;
+
+    fixture = TestBed.createComponent(DriverRegister);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create the component', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('Step Navigation', () => {
+    it('should start on step 1', () => {
+      expect(component.step()).toBe(1);
+    });
+
+    it('should advance to step 2 after handleStepOne', () => {
+      component.handleStepOne(mockStepOneData);
+      expect(component.step()).toBe(2);
+    });
+
+    it('should save step one data after handleStepOne', () => {
+      component.handleStepOne(mockStepOneData);
+      expect(component.savedStepOneData).toEqual(mockStepOneData);
+    });
+
+    it('should go back to step 1 when prevStep is called', () => {
+      component.handleStepOne(mockStepOneData);
+      component.prevStep(mockStepTwoData);
+      expect(component.step()).toBe(1);
+    });
+
+    it('should save step two data when going back', () => {
+      component.prevStep(mockStepTwoData);
+      expect(component.savedStepTwoData).toEqual(mockStepTwoData);
+    });
+  });
+
+  describe('handleStepTwo() - Registration', () => {
+    beforeEach(() => {
+      component.savedStepOneData = mockStepOneData;
+    });
+
+    it('should call authService.registerDriver with correct data', () => {
+      authService.registerDriver.and.returnValue(of('Success'));
+
+      component.handleStepTwo(mockStepTwoData);
+
+      expect(authService.registerDriver).toHaveBeenCalledWith(
+        jasmine.objectContaining({
+          firstName: 'John',
+          lastName: 'Doe',
+          phone: '+381641234567',
+          address: 'Bulevar Oslobodjenja 1',
+          email: 'driver@example.com',
+          vehicleModel: 'Toyota Corolla',
+          registrationPlate: 'NS-1234-AB',
+          seatNumber: 4,
+          petFriendly: false,
+          babyFriendly: false
+        }),
+        null
+      );
+    });
+
+    it('should pass pfpFile to registerDriver when file is selected', () => {
+      const mockFile = new File(['img'], 'photo.jpg', { type: 'image/jpeg' });
+      component.savedStepOneData = { ...mockStepOneData, pfpFile: mockFile };
+      authService.registerDriver.and.returnValue(of('Success'));
+
+      component.handleStepTwo(mockStepTwoData);
+
+      expect(authService.registerDriver).toHaveBeenCalledWith(
+        jasmine.any(Object),
+        mockFile
+      );
+    });
+
+    it('should pass null as file when no pfp selected', () => {
+      authService.registerDriver.and.returnValue(of('Success'));
+
+      component.handleStepTwo(mockStepTwoData);
+
+      expect(authService.registerDriver).toHaveBeenCalledWith(
+        jasmine.any(Object),
+        null
+      );
+    });
+
+    it('should reset to step 1 after successful registration', () => {
+      authService.registerDriver.and.returnValue(of('Success'));
+
+      component.handleStepOne(mockStepOneData);
+      component.handleStepTwo(mockStepTwoData);
+
+      expect(component.step()).toBe(1);
+    });
+
+    it('should clear saved data after registration', () => {
+      authService.registerDriver.and.returnValue(of('Success'));
+
+      component.handleStepTwo(mockStepTwoData);
+
+      expect(component.savedStepOneData).toBeUndefined();
+      expect(component.savedStepTwoData).toBeUndefined();
+    });
+
+    it('should handle registration error gracefully', () => {
+      authService.registerDriver.and.returnValue(throwError(() => ({ error: 'Error' })));
+
+      expect(() => component.handleStepTwo(mockStepTwoData)).not.toThrow();
+    });
+  });
+});

--- a/web/src/app/pages/ride-rating/ride-rating.spec.ts
+++ b/web/src/app/pages/ride-rating/ride-rating.spec.ts
@@ -66,7 +66,7 @@ describe('RideRatingComponent', () => {
     mockRatingService = jasmine.createSpyObj('RatingService', ['submitRating', 'getRatingStatus']);
     mockRideService = jasmine.createSpyObj('RideService', ['getPassengerRideDetail']);
     mockMapService = jasmine.createSpyObj('MapService', ['drawRoute', 'destroyMap']);
-    mockEstimationService = jasmine.createSpyObj('EstimationService', ['calculateRouteFromAddress']);
+    mockEstimationService = jasmine.createSpyObj('EstimationService', ['calculateRouteFromAddresses']);
 
     await TestBed.configureTestingModule({
       imports: [RideRatingComponent, ReactiveFormsModule],
@@ -87,7 +87,7 @@ describe('RideRatingComponent', () => {
 
     mockRatingService.getRatingStatus.and.returnValue(of(mockRatingStatus));
     mockRideService.getPassengerRideDetail.and.returnValue(of(mockRideDetails as any));
-    mockEstimationService.calculateRouteFromAddress.and.returnValue(of(mockEstimation as any));
+    mockEstimationService.calculateRouteFromAddresses.and.returnValue(of(mockEstimation as any));
 
     fixture = TestBed.createComponent(RideRatingComponent);
     component = fixture.componentInstance;
@@ -146,15 +146,15 @@ describe('RideRatingComponent', () => {
     it('should call map service to draw route when ride details loaded', fakeAsync(() => {
       component.ngOnInit();
       tick();
-      expect(mockEstimationService.calculateRouteFromAddress).toHaveBeenCalledWith(
-        '123 Main St',
-        '456 Oak Ave'
+      expect(mockEstimationService.calculateRouteFromAddresses).toHaveBeenCalledWith(
+        ['123 Main St',
+        '456 Oak Ave']
       );
       expect(mockMapService.drawRoute).toHaveBeenCalledWith(mockEstimation.routeGeometry as any);
     }));
 
     it('should handle route estimation error gracefully', fakeAsync(() => {
-      mockEstimationService.calculateRouteFromAddress.and.returnValue(throwError(() => new Error('Route Error')));
+      mockEstimationService.calculateRouteFromAddresses.and.returnValue(throwError(() => new Error('Route Error')));
       component.ngOnInit();
       tick();
       expect(component.rideDetails()).toEqual(mockRideDetails);
@@ -162,7 +162,7 @@ describe('RideRatingComponent', () => {
     }));
 
     it('should handle null estimation result', fakeAsync(() => {
-      mockEstimationService.calculateRouteFromAddress.and.returnValue(of(null));
+      mockEstimationService.calculateRouteFromAddresses.and.returnValue(of(null));
       component.ngOnInit();
       tick();
       expect(mockMapService.drawRoute).not.toHaveBeenCalled();

--- a/web/src/app/services/estimation.service.ts
+++ b/web/src/app/services/estimation.service.ts
@@ -17,7 +17,7 @@ export class EstimationService {
 
   private geocoding = inject(GeocodingService);
 
-  /*calculateRouteFromAddress(pickup: string, destination: string): Observable<RouteEstimation | null> {
+  calculateRouteFromAddress(pickup: string, destination: string): Observable<RouteEstimation | null> {
     return forkJoin({
       pickupLatLng: this.geocoding.geocodeAddress(pickup),
       destLatLng: this.geocoding.geocodeAddress(destination)
@@ -62,7 +62,7 @@ export class EstimationService {
     });
 
     return from(promise);
-  }*/
+  }
 
   // Prima niz stringova: [pickup, stop1, stop2, ..., destination]
   calculateRouteFromAddresses(addresses: string[]): Observable<RouteEstimation | null> {
@@ -77,13 +77,13 @@ export class EstimationService {
         if (latLngs.some(latLng => !latLng)) {
           return of(null);
         }
-        return this.calculateRouteFromCoords(latLngs as L.LatLng[]);
+        return this.calculateRouteFromCoordsArray(latLngs as L.LatLng[]);
       })
     );
   }
 
   // Prima niz L.LatLng koordinata
-  calculateRouteFromCoords(coords: L.LatLng[]): Observable<RouteEstimation | null> {
+  calculateRouteFromCoordsArray(coords: L.LatLng[]): Observable<RouteEstimation | null> {
     const promise = new Promise<RouteEstimation | null>((resolve) => {
       const router = L.Routing.osrmv1({
         serviceUrl: 'https://router.project-osrm.org/route/v1'


### PR DESCRIPTION
This pull request introduces comprehensive unit tests for the driver registration flow, including both form steps and the main registration component. Additionally, it refactors the `EstimationService` and its usage in ride rating tests to support multi-address route estimation, and updates related mocks and method calls for consistency.

**Driver Registration Testing:**

* Added unit tests for `StepOneForm`, covering form initialization, validation, file handling, and input patching.
* Added unit tests for `StepTwoForm`, including form validation, output emissions, back navigation, and input patching.
* Added unit tests for the `DriverRegister` component, verifying step navigation, data persistence, registration logic, and error handling.

**Estimation Service Refactor & Ride Rating Test Updates:**

* Refactored the `EstimationService` by restoring and exposing `calculateRouteFromAddress`, renaming the internal method to `calculateRouteFromCoordsArray`, and ensuring `calculateRouteFromAddresses` uses the new method name. [[1]](diffhunk://#diff-734627e22fdb3f1c5a347a5d76a0451f705918072182726a823cab7870600d59L20-R20) [[2]](diffhunk://#diff-734627e22fdb3f1c5a347a5d76a0451f705918072182726a823cab7870600d59L65-R65) [[3]](diffhunk://#diff-734627e22fdb3f1c5a347a5d76a0451f705918072182726a823cab7870600d59L80-R86)
* Updated ride rating tests to mock and assert calls to `calculateRouteFromAddresses` instead of the old `calculateRouteFromAddress`, ensuring compatibility with the refactored service. [[1]](diffhunk://#diff-b88ca3964321eef8430c6d4aecf10b75d8404c23ad581fe46a1c24c69219935fL69-R69) [[2]](diffhunk://#diff-b88ca3964321eef8430c6d4aecf10b75d8404c23ad581fe46a1c24c69219935fL90-R90) [[3]](diffhunk://#diff-b88ca3964321eef8430c6d4aecf10b75d8404c23ad581fe46a1c24c69219935fL149-R165)