### PR TITLE
#S123 Openapi

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -32,6 +32,15 @@
         <testng.version>7.8.0</testng.version>
     </properties>
     <dependencies>
+
+        <!-- Source: https://mvnrepository.com/artifact/org.springdoc/springdoc-openapi-starter-webmvc-ui -->
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.8.15</version>
+            <scope>compile</scope>
+        </dependency>
+
         <!-- Testing -->
         <dependency>
             <groupId>com.h2database</groupId>

--- a/backend/src/main/java/com/tricolori/backend/config/OpenApiConfig.java
+++ b/backend/src/main/java/com/tricolori/backend/config/OpenApiConfig.java
@@ -1,0 +1,32 @@
+package com.tricolori.backend.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI myOpenAPI() {
+        final String securitySchemeName = "bearerAuth";
+
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Tricolori API")
+                        .description("Backend documentation for Taxi application")
+                        .version("v1.0"))
+                .addSecurityItem(new SecurityRequirement().addList(securitySchemeName))
+                .components(new Components()
+                        .addSecuritySchemes(securitySchemeName,
+                                new SecurityScheme()
+                                        .name(securitySchemeName)
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("bearer")
+                                        .bearerFormat("JWT")));
+    }
+}

--- a/backend/src/main/java/com/tricolori/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/tricolori/backend/config/SecurityConfig.java
@@ -41,6 +41,12 @@ public class SecurityConfig {
             .sessionManagement(s ->
                     s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(a -> a
+                    .requestMatchers(
+                            "/v3/api-docs/**",
+                            "/v3/api-docs.yaml",
+                            "/swagger-ui/**",
+                            "/swagger-ui.html"
+                    ).permitAll()
                 .requestMatchers("/api/v1/auth/**", "/error").permitAll()
                 .requestMatchers("/api/v1/tracking/**").permitAll()
                 .requestMatchers("/api/v1/favorite-routes/**").hasRole("PASSENGER")

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -39,3 +39,6 @@ jwt.expiration=86400000
 
 # Colored output
 spring.output.ansi.enabled=ALWAYS
+
+# Spring Doc
+springdoc.packages-to-scan=com.tricolori.backend.controller


### PR DESCRIPTION
This pull request adds OpenAPI/Swagger documentation support to the backend, making it easier to explore and test the API via a web UI. It introduces the necessary dependencies, configuration, and security adjustments to enable and expose the Swagger UI and OpenAPI docs.

**OpenAPI/Swagger Integration:**

* Added the `springdoc-openapi-starter-webmvc-ui` dependency to `pom.xml` to enable Swagger UI and OpenAPI documentation generation.
* Created a new configuration file `OpenApiConfig.java` to define the OpenAPI specification, including API metadata and JWT bearer authentication scheme.
* Updated `application.properties` to specify which package should be scanned for API documentation generation.

**Security Configuration:**

* Modified `SecurityConfig.java` to allow unauthenticated access to Swagger UI and OpenAPI documentation endpoints, so the docs are accessible without login.