### PR TITLE
Mobile: shake sort

### DIFF
--- a/mobile/app/src/main/java/com/example/mobile/ui/fragments/history/RideHistoryFragment.java
+++ b/mobile/app/src/main/java/com/example/mobile/ui/fragments/history/RideHistoryFragment.java
@@ -1,6 +1,9 @@
 package com.example.mobile.ui.fragments.history;
 
 import android.app.DatePickerDialog;
+import android.content.Context;
+import android.hardware.Sensor;
+import android.hardware.SensorManager;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -21,6 +24,7 @@ import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 import com.example.mobile.R;
 import com.example.mobile.ui.fragments.RideDetailsDialogFragment;
 import com.example.mobile.ui.models.Ride;
+import com.example.mobile.utils.ShakeDetector;
 import com.google.android.material.textfield.TextInputEditText;
 import com.google.android.material.textfield.TextInputLayout;
 
@@ -56,6 +60,19 @@ public class RideHistoryFragment extends Fragment {
 
     // Adapter
     private PagedRideHistoryAdapter adapter;
+
+    private SensorManager sensorManager;
+    private ShakeDetector shakeDetector;
+
+    private static final String[][] SORT_CYCLE = {
+            {"createdAt", "DESC"},
+            {"createdAt", "ASC"},
+            {"price",     "DESC"},
+            {"price",     "ASC"},
+            {"status",    "ASC"},
+            {"route",     "ASC"},
+    };
+    private int sortCycleIndex = 0;
 
     private final SimpleDateFormat dateFormat =
             new SimpleDateFormat("yyyy-MM-dd", Locale.getDefault());
@@ -104,8 +121,26 @@ public class RideHistoryFragment extends Fragment {
         setupListeners();
         observeViewModel();
 
+        setupShakeDetector();
+
         // Initial load
         viewModel.loadRideHistory(requireContext());
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        Sensor accel = sensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER);
+        if (accel != null) {
+            sensorManager.registerListener(shakeDetector, accel,
+                    SensorManager.SENSOR_DELAY_UI);
+        }
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        sensorManager.unregisterListener(shakeDetector);
     }
 
     private void initViews(View view, RideHistoryViewModel.Role role) {
@@ -326,5 +361,23 @@ public class RideHistoryFragment extends Fragment {
         RideDetailsDialogFragment dialog =
                 RideDetailsDialogFragment.newInstance((long) ride.getId(), roleString);
         dialog.show(getParentFragmentManager(), "RideDetailsDialog");
+    }
+
+    private void setupShakeDetector() {
+        sensorManager = (SensorManager) requireContext()
+                .getSystemService(Context.SENSOR_SERVICE);
+
+        shakeDetector = new ShakeDetector();
+        shakeDetector.setOnShakeListener(count -> {
+            sortCycleIndex = (sortCycleIndex + 1) % SORT_CYCLE.length;
+            String col = SORT_CYCLE[sortCycleIndex][0];
+            String dir = SORT_CYCLE[sortCycleIndex][1];
+
+            viewModel.setSorting(col, dir);
+            viewModel.loadRideHistory(requireContext());
+
+            String msg = "Sort: " + col + " " + dir;
+            Toast.makeText(getContext(), msg, Toast.LENGTH_SHORT).show();
+        });
     }
 }

--- a/mobile/app/src/main/java/com/example/mobile/utils/ShakeDetector.java
+++ b/mobile/app/src/main/java/com/example/mobile/utils/ShakeDetector.java
@@ -1,0 +1,54 @@
+package com.example.mobile.utils;
+
+import android.hardware.Sensor;
+import android.hardware.SensorEvent;
+import android.hardware.SensorEventListener;
+import android.hardware.SensorManager;
+
+public class ShakeDetector implements SensorEventListener {
+
+    private static final float SHAKE_THRESHOLD_GRAVITY = 2.7f;
+    private static final int SHAKE_SLOP_TIME_MS = 500;
+    private static final int SHAKE_COUNT_RESET_TIME_MS = 3000;
+
+    public interface OnShakeListener {
+        void onShake(int count);
+    }
+
+    private OnShakeListener listener;
+    private long mShakeTimestamp;
+    private int mShakeCount;
+
+    public void setOnShakeListener(OnShakeListener listener) {
+        this.listener = listener;
+    }
+
+    @Override
+    public void onSensorChanged(SensorEvent event) {
+        if (listener == null) return;
+
+        float gX = event.values[0] / SensorManager.GRAVITY_EARTH;
+        float gY = event.values[1] / SensorManager.GRAVITY_EARTH;
+        float gZ = event.values[2] / SensorManager.GRAVITY_EARTH;
+
+        float gForce = (float) Math.sqrt(gX * gX + gY * gY + gZ * gZ);
+
+        if (gForce > SHAKE_THRESHOLD_GRAVITY) {
+            long now = System.currentTimeMillis();
+
+            if (mShakeTimestamp + SHAKE_SLOP_TIME_MS > now) return;
+
+            if (mShakeTimestamp + SHAKE_COUNT_RESET_TIME_MS < now) {
+                mShakeCount = 0;
+            }
+
+            mShakeTimestamp = now;
+            mShakeCount++;
+
+            listener.onShake(mShakeCount);
+        }
+    }
+
+    @Override
+    public void onAccuracyChanged(Sensor sensor, int accuracy) {}
+}


### PR DESCRIPTION
This pull request adds a shake-to-sort feature to the ride history screen in the mobile app. When the user shakes their device, the ride history list cycles through different sorting options (by date, price, status, and route) and displays a toast notification with the current sort order. The implementation includes a new `ShakeDetector` utility for detecting shake gestures and integrates it into the `RideHistoryFragment`.

**Shake gesture sorting feature:**

* Introduced a new `ShakeDetector` class in `mobile/app/src/main/java/com/example/mobile/utils/ShakeDetector.java` to detect device shake events and notify listeners.
* Added shake detection logic to `RideHistoryFragment`, including initialization of `SensorManager` and `ShakeDetector`, and registering/unregistering the sensor listener in `onResume`/`onPause`. [[1]](diffhunk://#diff-2d54fcb7d3387a56d4b23b02240b1f7e77999790b79993e3050da68e7728258bR4-R6) [[2]](diffhunk://#diff-2d54fcb7d3387a56d4b23b02240b1f7e77999790b79993e3050da68e7728258bR27) [[3]](diffhunk://#diff-2d54fcb7d3387a56d4b23b02240b1f7e77999790b79993e3050da68e7728258bR64-R76) [[4]](diffhunk://#diff-2d54fcb7d3387a56d4b23b02240b1f7e77999790b79993e3050da68e7728258bR124-R145)
* Implemented a sorting cycle (`SORT_CYCLE`) in `RideHistoryFragment` that rotates through different sort columns and directions each time a shake is detected, updating the ride history accordingly and displaying a toast message. [[1]](diffhunk://#diff-2d54fcb7d3387a56d4b23b02240b1f7e77999790b79993e3050da68e7728258bR64-R76) [[2]](diffhunk://#diff-2d54fcb7d3387a56d4b23b02240b1f7e77999790b79993e3050da68e7728258bR365-R382)